### PR TITLE
fix(moe): honor SwiGLU limits in rotated Trellis execution

### DIFF
--- a/b12x/moe/_shared/kernels/w4a16/kernel.py
+++ b/b12x/moe/_shared/kernels/w4a16/kernel.py
@@ -5918,10 +5918,9 @@ class W4A16FusedMoeKernel:
                 raise ValueError(
                     "intermediate_rotation is only supported for trellis_t256"
                 )
-            if not is_gated or self.activation_is_swigluoai or self.has_swiglu_limit:
+            if not is_gated or self.activation_is_swigluoai:
                 raise ValueError(
-                    "intermediate_rotation requires unclamped gated silu or situ "
-                    "(no swiglu limit/oai)"
+                    "intermediate_rotation requires gated silu or situ (not oai)"
                 )
             if int(intermediate_size) % 128 != 0:
                 raise ValueError(
@@ -7234,6 +7233,10 @@ class W4A16FusedMoeKernel:
                 b0, b1, b2, b3 = self._load_coupled_pre_quad(
                     fc1_flat, rotations_flat, row, expert, p0 + Int32(1), lane
                 )
+                a0, a1 = self._clamp_swiglu_inputs(a0, a1)
+                a2, a3 = self._clamp_swiglu_inputs(a2, a3)
+                b0, b1 = self._clamp_swiglu_inputs(b0, b1)
+                b2, b3 = self._clamp_swiglu_inputs(b2, b3)
                 if cutlass.const_expr(self.activation_is_situ):
                     beta = cutlass.Float32(SITU_DEFAULT_BETA)
                     linear_beta = cutlass.Float32(SITU_DEFAULT_LINEAR_BETA)
@@ -7394,6 +7397,10 @@ class W4A16FusedMoeKernel:
                 iu1 = uh1 * svu1
                 iu2 = uh2 * svu2
                 iu3 = uh3 * svu3
+                ig0, iu0 = self._clamp_swiglu_inputs(ig0, iu0)
+                ig1, iu1 = self._clamp_swiglu_inputs(ig1, iu1)
+                ig2, iu2 = self._clamp_swiglu_inputs(ig2, iu2)
+                ig3, iu3 = self._clamp_swiglu_inputs(ig3, iu3)
                 down = isz + isz
                 sd0 = rot_scales_flat[s_base + down + Int32(0)].to(cutlass.Float32)
                 sd1 = rot_scales_flat[s_base + down + Int32(1)].to(cutlass.Float32)
@@ -7717,6 +7724,13 @@ class W4A16FusedMoeKernel:
                 iu2_1 = uh1 * svu1
                 iu2_2 = uh2 * svu2
                 iu2_3 = uh3 * svu3
+                # Clamp the logical gate/up values after undoing the EXL3 FC1
+                # output rotations. This is the same point used by the plain
+                # activation arm and preserves DeepSeek's clamped SwiGLU.
+                ig2_0, iu2_0 = self._clamp_swiglu_inputs(ig2_0, iu2_0)
+                ig2_1, iu2_1 = self._clamp_swiglu_inputs(ig2_1, iu2_1)
+                ig2_2, iu2_2 = self._clamp_swiglu_inputs(ig2_2, iu2_2)
+                ig2_3, iu2_3 = self._clamp_swiglu_inputs(ig2_3, iu2_3)
                 # silu(gate) * up, then pre-scale suh_down
                 d2 = isz + isz
                 sd0 = rot_scales_flat[s_base + d2 + Int32(0)].to(cutlass.Float32)

--- a/tests/moe/test_fused_moe_trellis.py
+++ b/tests/moe/test_fused_moe_trellis.py
@@ -1262,8 +1262,11 @@ def test_planned_full_rotation_matches_reference_and_captures(
     relative_error = (mapped_eager - reference).norm() / reference.norm().clamp_min(
         1.0e-9
     )
+    assert torch.isfinite(mapped_eager).all()
+    assert torch.count_nonzero(mapped_eager) > 0
+    # Compute the angular metric in FP32 even when the public output is BF16.
     cosine = torch.nn.functional.cosine_similarity(
-        mapped_eager.flatten(), reference.flatten(), dim=0
+        mapped_eager.float().flatten(), reference.float().flatten(), dim=0
     )
     assert float(relative_error) <= 2.0e-2
     assert float(cosine) >= 0.999

--- a/tests/moe/test_fused_moe_trellis.py
+++ b/tests/moe/test_fused_moe_trellis.py
@@ -1134,6 +1134,7 @@ def test_full_rotation_topk16_route_parallel_sum_matches_reference(bits: int) ->
         (torch.bfloat16, "silu", 10.0),
         (torch.bfloat16, "situ", None),
         (torch.float16, "silu", None),
+        (torch.float16, "silu", 10.0),
         (torch.float16, "situ", None),
     ],
 )
@@ -1259,6 +1260,21 @@ def test_planned_full_rotation_matches_reference_and_captures(
         activation=activation,
         swiglu_limit=swiglu_limit,
     )
+    if swiglu_limit is not None:
+        unclamped = _reference_full_rotation(
+            x,
+            local_ids,
+            router_weights,
+            w13,
+            w2,
+            gate_suh,
+            up_suh,
+            intermediate_rotations,
+            down_svh,
+            activation=activation,
+        )
+        # Removing the clamps must exceed the tolerance of this oracle test.
+        assert float((reference - unclamped).norm() / reference.norm()) > 0.02
     relative_error = (mapped_eager - reference).norm() / reference.norm().clamp_min(
         1.0e-9
     )

--- a/tests/moe/test_fused_moe_trellis.py
+++ b/tests/moe/test_fused_moe_trellis.py
@@ -1200,8 +1200,7 @@ def test_planned_full_rotation_matches_reference_and_captures(
 
     spec = plan.scratch_specs()[0]
     scratch = torch.empty(spec.shape, dtype=spec.dtype, device=spec.device)
-    # Exercise the clamp in the clamped case; the historical tiny input never
-    # drove a reconstructed FC1 value past DeepSeek's limit.
+    # Use unit-scale input so reconstructed FC1 values exceed the configured limit.
     input_scale = 1.0 if swiglu_limit is not None else 1.0e-3
     x = (torch.randn((2, hidden), device=device) * input_scale).to(input_dtype)
     local_ids = torch.tensor([[0, 1], [1, 0]], dtype=torch.int32, device=device)

--- a/tests/moe/test_fused_moe_trellis.py
+++ b/tests/moe/test_fused_moe_trellis.py
@@ -219,6 +219,7 @@ def _plan(
     route_num_experts: int,
     block_size_m: int,
     device: torch.device | str,
+    swiglu_limit: float | None = None,
 ) -> fused_moe.Plan:
     return fused_moe.plan(
         fused_moe.Caps(
@@ -229,6 +230,7 @@ def _plan(
             weight_plan=weights.plan,
             quant_mode="w4a16",
             w4a16_block_size_m=block_size_m,
+            swiglu_limit=swiglu_limit,
         )
     )
 
@@ -606,6 +608,7 @@ def _reference_full_rotation(
     down_svh: torch.Tensor,
     *,
     activation: str = "silu",
+    swiglu_limit: float | None = None,
 ) -> torch.Tensor:
     device = x.device
     experts = int(w2.shape[0])
@@ -633,6 +636,7 @@ def _reference_full_rotation(
         intermediate_rotations,
         down_svh,
         activation=activation,
+        swiglu_limit=swiglu_limit,
     )
 
 
@@ -649,6 +653,7 @@ def _reference_full_rotation_decoded(
     down_svh: torch.Tensor,
     *,
     activation: str = "silu",
+    swiglu_limit: float | None = None,
 ) -> torch.Tensor:
     device = x.device
     experts = int(down_weights.shape[0])
@@ -690,6 +695,9 @@ def _reference_full_rotation_decoded(
                 svh=up_svh[expert],
                 store_fp16=True,
             )
+            if swiglu_limit is not None:
+                gate = gate.clamp(max=swiglu_limit)
+                up = up.clamp(min=-swiglu_limit, max=swiglu_limit)
             if activation == "situ":
                 activated = (
                     4.0
@@ -1119,11 +1127,20 @@ def test_full_rotation_topk16_route_parallel_sum_matches_reference(bits: int) ->
 
 
 @pytest.mark.skipif(not _sm12x_available(), reason="requires an SM120/SM121 GPU")
-@pytest.mark.parametrize("input_dtype", [torch.bfloat16, torch.float16])
-@pytest.mark.parametrize("activation", ["silu", "situ"])
+@pytest.mark.parametrize(
+    "input_dtype,activation,swiglu_limit",
+    [
+        (torch.bfloat16, "silu", None),
+        (torch.bfloat16, "silu", 10.0),
+        (torch.bfloat16, "situ", None),
+        (torch.float16, "silu", None),
+        (torch.float16, "situ", None),
+    ],
+)
 def test_planned_full_rotation_matches_reference_and_captures(
     input_dtype: torch.dtype,
     activation: str,
+    swiglu_limit: float | None,
 ) -> None:
     torch.manual_seed(20260721)
     device = torch.device("cuda", torch.cuda.current_device())
@@ -1175,13 +1192,17 @@ def test_planned_full_rotation_matches_reference_and_captures(
         route_num_experts=4,
         block_size_m=8,
         device=device,
+        swiglu_limit=swiglu_limit,
     )
     assert plan.caps.w4a16_block_size_m == 8
     assert plan.full_rotation
 
     spec = plan.scratch_specs()[0]
     scratch = torch.empty(spec.shape, dtype=spec.dtype, device=spec.device)
-    x = (torch.randn((2, hidden), device=device) * 1.0e-3).to(input_dtype)
+    # Exercise the clamp in the clamped case; the historical tiny input never
+    # drove a reconstructed FC1 value past DeepSeek's limit.
+    input_scale = 1.0 if swiglu_limit is not None else 1.0e-3
+    x = (torch.randn((2, hidden), device=device) * input_scale).to(input_dtype)
     local_ids = torch.tensor([[0, 1], [1, 0]], dtype=torch.int32, device=device)
     global_ids = torch.tensor([[1, 3], [3, 1]], dtype=torch.int64, device=device)
     router_weights = torch.tensor(
@@ -1236,6 +1257,7 @@ def test_planned_full_rotation_matches_reference_and_captures(
         intermediate_rotations,
         down_svh,
         activation=activation,
+        swiglu_limit=swiglu_limit,
     )
     relative_error = (mapped_eager - reference).norm() / reference.norm().clamp_min(
         1.0e-9


### PR DESCRIPTION
## Summary

Rotated Trellis execution rejects a configured SwiGLU limit, preventing the existing full-rotation path from preserving clamped activation semantics. Apply the existing gate/up clamp after undoing the FC1 output rotations and before the activation, including the coupled and staged rotation arms.

The regression uses inputs large enough to activate the limit and proves that an unclamped reference differs beyond the test tolerance. It covers FP16/BF16 inputs, caller-owned output, route maps, and graph replay; unclamped SiLU and SiTU remain controls.

## Validation

Upstream comparison: master `75ffee6375b0577ce2c8d6931ffacefda3ecbdd6`.

Six targeted GPU cases pass on RTX PRO 6000 Blackwell and GB10 with CUTLASS DSL 4.6.2. Both clamped cases fail on upstream during kernel construction; the four unclamped controls pass. The angular oracle computes in FP32, retaining the existing 0.999 threshold, with relative L2 <= 0.02 and finite/nonzero output.

```bash
python -m pytest -o addopts= -p no:cacheprovider -q tests/moe/test_fused_moe_trellis.py -k planned_full_rotation_matches_reference_and_captures
```

SiTU does not accept a SwiGLU limit in the public activation contract; that validation remains in place. No performance claim.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

Rotated Trellis execution now applies configured `swiglu_limit` values after undoing FC1 output rotations and before activation. The clamp applies to coupled, compact, and rotated activation paths.

Intermediate rotation validation now accepts configured limits for gated SiLU and SiTU. `SwiGLU-OAI` remains rejected. SiTU validation is unchanged.

Regression tests cover FP16 and BF16 inputs, caller-owned outputs, route maps, graph replay, and unclamped controls. The FP32 oracle checks cosine similarity, relative L2 error, and finite nonzero output. Six targeted GPU cases pass on RTX PRO 6000 Blackwell and GB10 with CUTLASS DSL 4.6.2.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->