### PR TITLE
fix(moe): preserve nine-bit local expert IDs in mixed Trellis descriptors

### DIFF
--- a/b12x/moe/_shared/kernels/w4a16/mixed_trellis.py
+++ b/b12x/moe/_shared/kernels/w4a16/mixed_trellis.py
@@ -241,8 +241,8 @@ class W4A16MixedTrellisKernel:
                 "mixed Trellis FC2 schedule factor must divide one packed "
                 f"route block: factor={fc2_factor}, maximum={expected_factor}"
             )
-        if tier0.num_experts > 256 or tier1.num_experts > 256:
-            raise ValueError("tier-local expert ids must fit in eight bits")
+        if tier0.num_experts > _MAX_TIER_EXPERTS or tier1.num_experts > _MAX_TIER_EXPERTS:
+            raise ValueError("tier-local expert ids must fit in nine bits")
         if driver.num_experts != tier0.num_experts + tier1.num_experts:
             raise ValueError("driver expert count must equal the sum of both tiers")
         self.driver = driver
@@ -404,8 +404,8 @@ class W4A16MixedTrellisKernel:
                 descriptor_row * total_experts + combined_expert
             ].to(Int32)
             if descriptor >= Int32(0):
-                tier = descriptor >> Int32(8)
-                local_expert = descriptor & Int32(0xFF)
+                tier = descriptor >> Int32(_TIER_DESCRIPTOR_BITS)
+                local_expert = descriptor & Int32(_TIER_DESCRIPTOR_MASK)
                 # FC1 is bounded by the tier's FC1 slot count; FC2 by its own
                 # independent count, since per-projection membership lets the
                 # two differ. Both remain real bounds.
@@ -1003,7 +1003,7 @@ class W4A16MixedTrellis3Kernel(W4A16MixedTrellisKernel):
             )
         tiers = (tier0, tier1, tier2)
         if any(tier.num_experts > _MAX_TIER_EXPERTS for tier in tiers):
-            raise ValueError("tier-local expert ids must fit in eight bits")
+            raise ValueError("tier-local expert ids must fit in nine bits")
         if driver.num_experts != sum(tier.num_experts for tier in tiers):
             raise ValueError("driver expert count must equal the sum of all tiers")
         self.driver = driver
@@ -1103,8 +1103,8 @@ class W4A16MixedTrellis3Kernel(W4A16MixedTrellisKernel):
                 descriptor_row * total_experts + combined_expert
             ].to(Int32)
             if descriptor >= Int32(0):
-                tier = descriptor >> Int32(8)
-                local_expert = descriptor & Int32(0xFF)
+                tier = descriptor >> Int32(_TIER_DESCRIPTOR_BITS)
+                local_expert = descriptor & Int32(_TIER_DESCRIPTOR_MASK)
 
                 if cutlass.const_expr(is_fc1):
                     t0_in_bounds = local_expert < tier0_gate_experts
@@ -2008,7 +2008,7 @@ def compile_mixed_trellis3(
     )
     if any(value <= 0 or value > _MAX_TIER_EXPERTS for value in counts):
         raise ValueError(
-            "three-tier mixed Trellis requires each tier to contain 1..256 slots"
+            "three-tier mixed Trellis requires each tier to contain 1..512 slots"
         )
     bits = tuple(int(value) for value in (tier0_bits, tier1_bits, tier2_bits))
     if set(bits) != {3, 4, 5}:
@@ -2341,8 +2341,11 @@ def build_ordered_maps(
     )
 
 
-# One tier-local expert index is encoded in the descriptor's low 8 bits.
-_MAX_TIER_EXPERTS = 256
+# Descriptors are in-process artifacts, not checkpoint storage. Nine local
+# index bits cover a projection tier containing all 288 GLM experts.
+_TIER_DESCRIPTOR_BITS = 9
+_TIER_DESCRIPTOR_MASK = (1 << _TIER_DESCRIPTOR_BITS) - 1
+_MAX_TIER_EXPERTS = 1 << _TIER_DESCRIPTOR_BITS
 
 
 def build_tiered_maps(
@@ -2355,8 +2358,8 @@ def build_tiered_maps(
 
     tier0_ids = tuple(int(expert_id) for expert_id in tier0_global_ids)
     tier1_ids = tuple(int(expert_id) for expert_id in tier1_global_ids)
-    if len(tier0_ids) > 256 or len(tier1_ids) > 256:
-        raise ValueError("each mixed Trellis tier supports at most 256 experts")
+    if len(tier0_ids) > _MAX_TIER_EXPERTS or len(tier1_ids) > _MAX_TIER_EXPERTS:
+        raise ValueError("each mixed Trellis tier supports at most 512 experts")
     total = len(tier0_ids) + len(tier1_ids)
     if sorted((*tier0_ids, *tier1_ids)) != list(range(total)):
         raise ValueError(
@@ -2371,7 +2374,7 @@ def build_tiered_maps(
         global_to_combined_host, dtype=torch.int32, device=device
     )
     descriptor_row = torch.tensor(
-        [*range(len(tier0_ids)), *((1 << 8) | i for i in range(len(tier1_ids)))],
+        [*range(len(tier0_ids)), *((1 << _TIER_DESCRIPTOR_BITS) | i for i in range(len(tier1_ids)))],
         dtype=torch.int32,
         device=device,
     )
@@ -2404,7 +2407,7 @@ def build_projection_tiered_maps(
 
     Returns ``(global_to_combined, descriptor_map)``. ``descriptor_map`` is a
     contiguous ``int32[3 * sum(tier_slots)]`` tensor laid out as gate, up, and
-    down rows. A populated entry encodes ``(tier << 8) | tier_local_index``;
+    down rows. A populated entry encodes ``(tier << _TIER_DESCRIPTOR_BITS) | tier_local_index``;
     unused padded slots contain ``-1``.
     """
 
@@ -2418,8 +2421,8 @@ def build_projection_tiered_maps(
         raise ValueError(
             "mixed Trellis tier_slots must contain exactly two or three counts"
         )
-    if any(value < 0 or value > 256 for value in slots):
-        raise ValueError("mixed Trellis tier slots must be in [0, 256]")
+    if any(value < 0 or value > _MAX_TIER_EXPERTS for value in slots):
+        raise ValueError("mixed Trellis tier slots must be in [0, 512]")
     num_experts = len(projections[0][1])
     rows: list[int] = []
     projection_counts: list[tuple[int, ...]] = []
@@ -2438,11 +2441,11 @@ def build_projection_tiered_maps(
         for tier in tiers:
             local = counters[tier]
             counters[tier] += 1
-            if local > 0xFF:
+            if local > _TIER_DESCRIPTOR_MASK:
                 raise ValueError(
-                    f"mixed Trellis {name} tier {tier} exceeds 256 experts"
+                    f"mixed Trellis {name} tier {tier} exceeds 512 experts"
                 )
-            row.append((tier << 8) | local)
+            row.append((tier << _TIER_DESCRIPTOR_BITS) | local)
         projection_counts.append(tuple(counters))
         rows.extend(row)
     # The launch sizes the descriptor namespace as the sum of the tier slot
@@ -2505,7 +2508,7 @@ def _check_descriptor_projection_counts(
         tier_count = len(gate_counts)
         for row in rows[:2]:
             live = row[row >= 0]
-            encoded_tiers = live >> 8
+            encoded_tiers = live >> _TIER_DESCRIPTOR_BITS
             if bool((encoded_tiers >= tier_count).any()):
                 raise ValueError(
                     "mixed Trellis descriptor contains a tier outside the "

--- a/tests/moe/test_w4a16_mixed_trellis.py
+++ b/tests/moe/test_w4a16_mixed_trellis.py
@@ -1741,3 +1741,104 @@ def test_glm52_large_m_mixed_k3_k4_matches_serial() -> None:
     # mixed grid reduces them in one schedule. Normal rounding stays below
     # 1e-4; the unsafe 64x256 FC1 geometry was three orders larger (~8e-3).
     assert float(relative) < 1.0e-4
+
+
+@pytest.mark.skipif(not _sm12x_available(), reason="requires an SM120/SM121 GPU")
+@pytest.mark.parametrize("tier_count", [2, 3])
+def test_mixed_descriptor_high_local_experts_match_serial_and_replay(
+    tier_count: int,
+) -> None:
+    """Exercise every tier tag at local indices 255, 256 and 511 on the GPU."""
+    torch.manual_seed(20260909)
+    device = torch.device("cuda", torch.cuda.current_device())
+    count, rows, hidden = 512, 3, 128
+    tiers = tuple(
+        _prepared(
+            experts=count,
+            hidden=hidden,
+            intermediate=hidden,
+            bits=3 + i,
+            seed=730 + i,
+            device=device,
+            codebook="mcg",
+        )
+        for i in range(tier_count)
+    )
+    ids = torch.tensor(
+        [
+            [tier * count + local for tier in range(tier_count)]
+            for local in (255, 256, 511)
+        ],
+        dtype=torch.int32,
+        device=device,
+    )
+    router = torch.softmax(torch.randn((rows, tier_count), device=device), dim=-1)
+    x = (torch.randn((rows, hidden), device=device) * 1e-3).bfloat16()
+    serial = torch.zeros((rows, hidden), device=device)
+    for i, tier in enumerate(tiers):
+        expert_map = torch.full(
+            (tier_count * count,), -1, dtype=torch.int32, device=device
+        )
+        expert_map[i * count : (i + 1) * count] = torch.arange(
+            count, dtype=torch.int32, device=device
+        )
+        serial.add_(_serial_tier(x, tier, router, ids, expert_map))
+    props = torch.cuda.get_device_properties(device)
+    kwargs = dict(
+        size_m=rows,
+        hidden_size=hidden,
+        intermediate_size=hidden,
+        tier0_num_experts=count,
+        tier1_num_experts=count,
+        top_k=tier_count,
+        max_m_blocks=tier_count * rows,
+        sms=int(props.multi_processor_count),
+        max_shared_mem=int(props.shared_memory_per_block_optin),
+        force_tile_config=(128, 128, 128, 128),
+        trellis_codebook="mcg",
+    )
+    if tier_count == 2:
+        launch = compile_mixed_trellis(**kwargs)
+        mapping, descriptor = build_tiered_maps(
+            tuple(range(count)), tuple(range(count, 2 * count)), device=device
+        )
+        make_buffers, bind, run = (
+            make_mixed_trellis_buffers,
+            bind_mixed_trellis,
+            run_bound_mixed_trellis,
+        )
+    else:
+        launch = compile_mixed_trellis3(
+            **kwargs, tier2_num_experts=count, route_num_experts=3 * count
+        )
+        assignments = tuple(tier for tier in range(3) for _ in range(count))
+        mapping, descriptor = build_projection_tiered_maps(
+            assignments,
+            assignments,
+            assignments,
+            tier_slots=(count,) * 3,
+            device=device,
+        )
+        make_buffers, bind, run = (
+            make_mixed_trellis3_buffers,
+            bind_mixed_trellis3,
+            run_bound_mixed_trellis3,
+        )
+    buffers = make_buffers(launch, device=device, sms=int(props.multi_processor_count))
+    binding = bind(
+        *tiers, mapping, descriptor, combine_trellis_rotations(*tiers), launch
+    )
+    eager = run(x, router, ids, binding, buffers).clone()
+    assert torch.isfinite(eager).all() and torch.count_nonzero(eager) > 0
+    assert float((eager.float() - serial).norm() / serial.norm()) < 4e-3
+    graph = torch.cuda.CUDAGraph()
+    with torch.cuda.graph(graph):
+        captured = run(x, router, ids, binding, buffers)
+    pointer = captured.data_ptr()
+    captured.fill_(float("nan"))
+    allocated = torch.cuda.memory_allocated(device)
+    graph.replay()
+    torch.cuda.synchronize(device)
+    assert torch.equal(captured, eager)
+    assert captured.data_ptr() == pointer
+    assert torch.cuda.memory_allocated(device) == allocated

--- a/tests/moe/test_w4a16_mixed_trellis.py
+++ b/tests/moe/test_w4a16_mixed_trellis.py
@@ -1356,7 +1356,7 @@ def test_build_tiered_maps_repeats_projection_independent_descriptor_row() -> No
     )
     assert route.tolist() == [1, 3, 0, 2]
     rows = descriptor.reshape(3, 4)
-    assert rows[0].tolist() == [0, 1, 1 << 8, (1 << 8) | 1]
+    assert rows[0].tolist() == [0, 1, 1 << 9, (1 << 9) | 1]
     assert torch.equal(rows[0], rows[1])
     assert torch.equal(rows[0], rows[2])
 
@@ -1379,11 +1379,11 @@ def test_projection_tiered_maps_pad_each_row_to_slot_stride() -> None:
     rows = descriptor.reshape(3, 257)
     assert torch.equal(rows[:, -1], torch.full((3,), -1, dtype=torch.int32))
     assert rows[0, 128].item() == 128
-    assert rows[0, 129].item() == 1 << 8
+    assert rows[0, 129].item() == 1 << 9
     assert rows[1, 127].item() == 127
-    assert rows[1, 128].item() == 1 << 8
+    assert rows[1, 128].item() == 1 << 9
     assert rows[2, 76].item() == 76
-    assert rows[2, 77].item() == 1 << 8
+    assert rows[2, 77].item() == 1 << 9
 
 
 def test_projection_route_namespace_must_match_the_map() -> None:
@@ -1451,6 +1451,27 @@ def test_projection_tiered_maps_support_an_empty_tier() -> None:
     assert rows[:, 255].tolist() == [255, 255, 255]
 
 
+@pytest.mark.parametrize("experts", [255, 256, 288, 512])
+@pytest.mark.parametrize("tier", [0, 1, 2])
+def test_projection_tiered_maps_preserve_tier_and_local_index(
+    experts: int, tier: int,
+) -> None:
+    tiers = [tier] * experts
+    slots = tuple(experts if index == tier else 0 for index in range(3))
+    route, descriptor = build_projection_tiered_maps(
+        tiers,
+        tiers,
+        tiers,
+        tier_slots=slots,
+        device=torch.device("cpu"),
+    )
+
+    assert route.tolist() == list(range(experts))
+    rows = descriptor.reshape(3, experts)
+    assert torch.equal(rows >> 9, torch.full_like(rows, tier))
+    assert torch.equal(rows & 511, torch.arange(experts).expand(3, -1))
+
+
 @pytest.mark.parametrize("slots", [(256,), (256, 0, 0, 0)])
 def test_projection_tiered_maps_reject_wrong_slot_arity(slots) -> None:
     with pytest.raises(ValueError, match="exactly two or three"):
@@ -1459,9 +1480,9 @@ def test_projection_tiered_maps_reject_wrong_slot_arity(slots) -> None:
         )
 
 
-@pytest.mark.parametrize("slots", [(-1, 2), (300, -44)])
+@pytest.mark.parametrize("slots", [(-1, 2), (513, 0)])
 def test_projection_tiered_maps_reject_invalid_slots(slots) -> None:
-    with pytest.raises(ValueError, match=r"\[0, 256\]"):
+    with pytest.raises(ValueError, match=r"\[0, 512\]"):
         build_projection_tiered_maps(
             [0], [0], [0], tier_slots=slots, device=torch.device("cpu")
         )
@@ -1478,9 +1499,9 @@ def test_projection_tiered_maps_encode_gate_up_and_down_independently() -> None:
 
     assert route.tolist() == [0, 1, 2, 3]
     assert descriptor.view(3, 6).tolist() == [
-        [0, 1 << 8, 1, 2 << 8, -1, -1],
-        [1 << 8, (1 << 8) | 1, 2 << 8, 0, -1, -1],
-        [2 << 8, 0, (2 << 8) | 1, 1 << 8, -1, -1],
+        [0, 1 << 9, 1, 2 << 9, -1, -1],
+        [1 << 9, (1 << 9) | 1, 2 << 9, 0, -1, -1],
+        [2 << 9, 0, (2 << 9) | 1, 1 << 9, -1, -1],
     ]
     assert descriptor._mt_projection_counts == ((2, 1, 1), (1, 2, 1))
 


### PR DESCRIPTION
## Summary

A mixed Trellis projection tier can contain more than 256 local experts, including a 288-expert projection. The eight-bit descriptor field cannot represent that layout. Reserve nine bits for the local index, move the tier tag consistently in the builders and both GPU decoders, and validate the 512-slot per-tier bound.

Keep projection-specific gate/up/down counts and all three tier tags distinct.

## Validation

Upstream comparison: master `75ffee6375b0577ce2c8d6931ffacefda3ecbdd6`.

22 CPU boundary/descriptor tests and two GPU dispatch/replay tests pass on GB10. The GPU tests also pass on RTX PRO 6000 Blackwell; both use CUTLASS DSL 4.6.2. CPU cases cover 255/256/288/512 slots and reject 513. GPU routes exercise local IDs 255, 256 and 511 in every tier of two-tier and three-tier kernels, compare against serial tier execution (relative L2 < 0.004), and poison/replay the output with stable storage. Both GPU cases fail on upstream's capacity checks.

```bash
python -m pytest -o addopts= -p no:cacheprovider -q tests/moe/test_w4a16_mixed_trellis.py -k 'mixed_descriptor_high or build_tiered_maps or projection_tiered_maps or descriptor_projection_count'
```

No routing-policy or attention changes; no performance claim.
