### PR TITLE
fix(gemm): honor bound scratch in inverse-RoPE WO projection

### DIFF
--- a/b12x/gemm/_shared/wo_mxfp8.py
+++ b/b12x/gemm/_shared/wo_mxfp8.py
@@ -2966,8 +2966,14 @@ def wo_projection_inv_rope_mxfp8(
     expected_m: int | None = None,
     stream: object = None,
 ) -> torch.Tensor:
-    """Run WO projection from attention output without BF16 inverse-RoPE storage."""
+    """Run WO projection from attention output without BF16 inverse-RoPE storage.
 
+    The planned binding path writes every intermediate and the final output
+    into caller-owned arena views.  The functional path retains the opaque
+    allocating op needed by dynamic ``torch.compile`` callers.
+    """
+
+    bound_views = binding is not None
     if binding is not None:
         extras = [
             name
@@ -3006,6 +3012,10 @@ def wo_projection_inv_rope_mxfp8(
         rope_dim = binding.rope_dim
         return_3d = binding.return_3d
         expected_m = binding.expected_m
+        x_q = binding.x_q
+        tmp = binding.tmp
+        tmp_q = binding.tmp_q
+        output = binding.output
     if (
         o is None
         or positions is None
@@ -3030,10 +3040,62 @@ def wo_projection_inv_rope_mxfp8(
     # wo_projection_mxfp8); decode -> 32x128, prefill -> 64x128, no caller change.
     if expected_m is None:
         expected_m = int(tokens)
+    if bound_views:
+        alpha_one = _cached_alpha_one(o.device)
+        atomic_output_precleared = tokens <= 8
+        _run_wo_a_quant_kernel(
+            o,
+            positions,
+            cos_sin_cache,
+            x_q.values,
+            x_q.scale_rows,
+            x_q.scale_mma,
+            tokens,
+            weights.groups,
+            heads_per_group,
+            weights.group_width,
+            nope_dim + rope_dim,
+            nope_dim,
+            rope_dim,
+            clear_output=output if atomic_output_precleared else None,
+        )
+        wo_a_dense_gemm_mxfp8(
+            x_q,
+            weights.wo_a,
+            out=tmp,
+            alpha=alpha_one,
+            expected_m=expected_m,
+            sfb_k_replicated=weights.sfb_k_replicated,
+            stream=stream,
+        )
+        if atomic_output_precleared:
+            wo_b_dense_gemm_fused_quant_mxfp8(
+                tmp,
+                weights.wo_b,
+                out=output,
+                expected_m=expected_m,
+                sfb_k_replicated=weights.sfb_k_replicated,
+                _atomic_output_precleared=True,
+                stream=stream,
+            )
+        else:
+            quantize_wo_b_input_mxfp8(tmp, out=tmp_q)
+            wo_b_dense_gemm_mxfp8(
+                tmp_q,
+                weights.wo_b,
+                out=output,
+                alpha=alpha_one,
+                expected_m=expected_m,
+                sfb_k_replicated=weights.sfb_k_replicated,
+                stream=stream,
+            )
+        if return_3d:
+            return output
+        return output[:, :, 0]
     # One fully opaque fused op runs the whole quantize -> gemm -> quantize ->
     # gemm chain internally, so the token-shaped activation MXFP8 views never
     # become graph values (see _wo_projection_inv_rope_mxfp8_fused_op). Any
-    # bound scratch is intentionally unused here.
+    # functional-path intermediates remain internal here.
     output = torch.ops.b12x.wo_projection_inv_rope_mxfp8_fused(
         o,
         positions,

--- a/b12x/gemm/_shared/wo_mxfp8.py
+++ b/b12x/gemm/_shared/wo_mxfp8.py
@@ -102,6 +102,44 @@ class WOProjectionMXFP8Weights:
 
 
 @dataclass(frozen=True)
+class _WOInvRopeRoute:
+    """Kernel sequence retained by a fixed-shape inverse-RoPE binding."""
+
+    atomic_output_precleared: bool
+    quantized_intermediate: bool
+
+
+def _select_wo_inv_rope_route(
+    *,
+    tokens: int,
+    sm_count: int,
+    weights: WOProjectionMXFP8Weights,
+    heads_per_group: int,
+    nope_dim: int,
+    rope_dim: int,
+) -> _WOInvRopeRoute:
+    """Share the functional route rules with binding-time selection."""
+    quantized_intermediate = _should_use_exact_b16_wo(
+        tokens=tokens,
+        sm_count=sm_count,
+    ) or (
+        9 <= tokens <= 15
+        and sm_count <= _WO_SPARK_MAX_SMS
+        and weights.groups == 4
+        and weights.group_width == 512
+        and weights.rank == 1024
+        and weights.hidden == 4096
+        and heads_per_group == 1
+        and nope_dim == 448
+        and rope_dim == 64
+    )
+    return _WOInvRopeRoute(
+        atomic_output_precleared=tokens <= 8,
+        quantized_intermediate=quantized_intermediate,
+    )
+
+
+@dataclass(frozen=True)
 class _WOProjectionScratchViews:
     x_q: MXFP8Rows
     tmp: torch.Tensor
@@ -128,6 +166,7 @@ class WOProjectionBinding:
 
 @dataclass(frozen=True, kw_only=True)
 class WOProjectionInvRopeBinding:
+    route: _WOInvRopeRoute
     o: torch.Tensor
     positions: torch.Tensor
     cos_sin_cache: torch.Tensor
@@ -2262,7 +2301,22 @@ def _build_wo_projection_inv_rope_binding_from_views(
         tokens=tokens,
         weights=weights,
     )
+    # Bindings own fixed-shape capture buckets; execution consumes this route.
+    sm_count = (
+        torch.cuda.get_device_properties(o.device).multi_processor_count
+        if o.device.type == "cuda"
+        else _WO_SPARK_MAX_SMS + 1
+    )
+    route = _select_wo_inv_rope_route(
+        tokens=tokens,
+        sm_count=sm_count,
+        weights=weights,
+        heads_per_group=heads_per_group,
+        nope_dim=nope_dim,
+        rope_dim=rope_dim,
+    )
     return WOProjectionInvRopeBinding(
+        route=route,
         o=o,
         positions=positions,
         cos_sin_cache=cos_sin_cache,
@@ -2801,7 +2855,15 @@ def _wo_projection_inv_rope_mxfp8_fused_op(
     # uint8 unity-fill launches; poisoned-padding tests pin that it cannot
     # affect a logical output row. Standalone quantizers retain initialized
     # padding.
-    atomic_output_precleared = tokens <= 8
+    route = _select_wo_inv_rope_route(
+        tokens=tokens,
+        sm_count=torch.cuda.get_device_properties(o.device).multi_processor_count,
+        weights=weights,
+        heads_per_group=heads_per_group,
+        nope_dim=nope_dim,
+        rope_dim=rope_dim,
+    )
+    atomic_output_precleared = route.atomic_output_precleared
     output = None
     if atomic_output_precleared:
         output = torch.empty((tokens, hidden, 1), dtype=torch.bfloat16, device=o.device)
@@ -2847,24 +2909,7 @@ def _wo_projection_inv_rope_mxfp8_fused_op(
             rope_dim=rope_dim,
             _initialize_scales=False,
         )
-    sm_count = torch.cuda.get_device_properties(o.device).multi_processor_count
-    # Keep upstream's Spark-only B16 policy. The B9-15 extension is likewise
-    # retained only for the measured DSV4 TP2 inverse-RoPE contract.
-    use_quantized_intermediate = _should_use_exact_b16_wo(
-        tokens=tokens,
-        sm_count=sm_count,
-    ) or (
-        9 <= tokens <= 15
-        and sm_count <= _WO_SPARK_MAX_SMS
-        and groups == 4
-        and group_width == 512
-        and rank == 1024
-        and hidden == 4096
-        and heads_per_group == 1
-        and nope_dim == 448
-        and rope_dim == 64
-    )
-    if use_quantized_intermediate:
+    if route.quantized_intermediate:
         tmp_q_bases = empty_mxfp8_rows_bases(
             tokens,
             rank * groups,
@@ -2901,7 +2946,7 @@ def _wo_projection_inv_rope_mxfp8_fused_op(
         sfb_k_replicated=weights.sfb_k_replicated,
         stream=stream_int,
     )
-    if tokens <= 8 and tmp.dtype == torch.bfloat16:
+    if route.atomic_output_precleared and tmp.dtype == torch.bfloat16:
         # Decode band: quantize the group-major WO-B input inside the GEMM's
         # DMA warp instead of launching a standalone quant kernel.
         return wo_b_dense_gemm_fused_quant_mxfp8(
@@ -3041,8 +3086,8 @@ def wo_projection_inv_rope_mxfp8(
     if expected_m is None:
         expected_m = int(tokens)
     if bound_views:
-        alpha_one = _cached_alpha_one(o.device)
-        atomic_output_precleared = tokens <= 8
+        route = binding.route
+        atomic_output_precleared = route.atomic_output_precleared
         _run_wo_a_quant_kernel(
             o,
             positions,
@@ -3059,36 +3104,55 @@ def wo_projection_inv_rope_mxfp8(
             rope_dim,
             clear_output=output if atomic_output_precleared else None,
         )
-        wo_a_dense_gemm_mxfp8(
-            x_q,
-            weights.wo_a,
-            out=tmp,
-            alpha=alpha_one,
-            expected_m=expected_m,
-            sfb_k_replicated=weights.sfb_k_replicated,
-            stream=stream,
-        )
-        if atomic_output_precleared:
-            wo_b_dense_gemm_fused_quant_mxfp8(
-                tmp,
-                weights.wo_b,
-                out=output,
+        if route.quantized_intermediate:
+            wo_a_dense_gemm_mxfp8(
+                x_q,
+                weights.wo_a,
+                quantized_out=tmp_q,
                 expected_m=expected_m,
                 sfb_k_replicated=weights.sfb_k_replicated,
-                _atomic_output_precleared=True,
                 stream=stream,
             )
-        else:
-            quantize_wo_b_input_mxfp8(tmp, out=tmp_q)
             wo_b_dense_gemm_mxfp8(
                 tmp_q,
                 weights.wo_b,
                 out=output,
+                expected_m=expected_m,
+                sfb_k_replicated=weights.sfb_k_replicated,
+                stream=stream,
+            )
+        else:
+            alpha_one = _cached_alpha_one(o.device)
+            wo_a_dense_gemm_mxfp8(
+                x_q,
+                weights.wo_a,
+                out=tmp,
                 alpha=alpha_one,
                 expected_m=expected_m,
                 sfb_k_replicated=weights.sfb_k_replicated,
                 stream=stream,
             )
+            if atomic_output_precleared:
+                wo_b_dense_gemm_fused_quant_mxfp8(
+                    tmp,
+                    weights.wo_b,
+                    out=output,
+                    expected_m=expected_m,
+                    sfb_k_replicated=weights.sfb_k_replicated,
+                    _atomic_output_precleared=True,
+                    stream=stream,
+                )
+            else:
+                quantize_wo_b_input_mxfp8(tmp, out=tmp_q)
+                wo_b_dense_gemm_mxfp8(
+                    tmp_q,
+                    weights.wo_b,
+                    out=output,
+                    alpha=alpha_one,
+                    expected_m=expected_m,
+                    sfb_k_replicated=weights.sfb_k_replicated,
+                    stream=stream,
+                )
         if return_3d:
             return output
         return output[:, :, 0]

--- a/tests/gemm/test_gemm_wo_projection.py
+++ b/tests/gemm/test_gemm_wo_projection.py
@@ -70,6 +70,46 @@ def _make_wo_projection_binding(
     )
 
 
+def _make_wo_projection_inv_rope_binding(
+    o: torch.Tensor,
+    positions: torch.Tensor,
+    cos_sin_cache: torch.Tensor,
+    weights,
+    *,
+    heads_per_group: int,
+    nope_dim: int,
+    rope_dim: int,
+    expected_m: int | None = None,
+):
+    tokens = int(o.shape[0])
+    plan = plan_wo_projection_scratch(
+        WOProjectionScratchCaps(
+            device=o.device,
+            max_tokens=tokens,
+            groups=int(weights.groups),
+            group_width=int(weights.group_width),
+            rank=int(weights.rank),
+            hidden=int(weights.hidden),
+            dtype=o.dtype,
+        )
+    )
+    scratch = tuple(
+        torch.empty(shape, dtype=dtype, device=o.device)
+        for shape, dtype in plan.shapes_and_dtypes()
+    )
+    return plan.bind_inv_rope(
+        scratch=scratch,
+        o=o,
+        positions=positions,
+        cos_sin_cache=cos_sin_cache,
+        weights=weights,
+        heads_per_group=heads_per_group,
+        nope_dim=nope_dim,
+        rope_dim=rope_dim,
+        expected_m=expected_m,
+    )
+
+
 def _sglang_wo_a_input_quant_reference(source_tgd: torch.Tensor) -> MXFP8Rows:
     tokens, groups, group_width = source_tgd.shape
     chunks = group_width // WO_A_INPUT_QUANT_GROUP_SIZE
@@ -734,6 +774,93 @@ def test_inv_rope_fused_wo_replays_under_graph_with_uninitialized_scale_padding(
     assert bool(torch.isfinite(replayed).all().item())
     assert bool((replayed != 0).any().item())
     torch.testing.assert_close(replayed, expected, rtol=0, atol=0)
+
+
+@pytest.mark.parametrize("tokens", (1, 16))
+def test_inv_rope_planned_wo_uses_bound_arena_and_replays_under_graph(
+    tokens: int,
+) -> None:
+    require_b12x()
+    torch.manual_seed(31014 + tokens)
+
+    groups, heads_per_group = 2, 4
+    nope_dim, rope_dim = 96, 32
+    head_dim = nope_dim + rope_dim
+    group_width = heads_per_group * head_dim
+    rank, hidden = 64, 128
+    o = (
+        torch.randn(
+            (tokens, groups * heads_per_group, head_dim),
+            device="cuda",
+            dtype=torch.bfloat16,
+        )
+        / 4
+    ).contiguous()
+    positions = torch.arange(tokens, device="cuda", dtype=torch.int64)
+    cos_sin_cache = torch.zeros(
+        (tokens + 1, rope_dim), device="cuda", dtype=torch.float32
+    )
+    cos_sin_cache[:, : rope_dim // 2] = 1
+    wo_a = (
+        torch.randn(
+            (groups, rank, group_width), device="cuda", dtype=torch.bfloat16
+        )
+        / group_width**0.5
+    )
+    wo_b = (
+        torch.randn(
+            (hidden, groups * rank), device="cuda", dtype=torch.bfloat16
+        )
+        / (groups * rank) ** 0.5
+    )
+    weights = quantize_wo_projection_weights_mxfp8_torch(wo_a, wo_b)
+    binding = _make_wo_projection_inv_rope_binding(
+        o,
+        positions,
+        cos_sin_cache,
+        weights,
+        heads_per_group=heads_per_group,
+        nope_dim=nope_dim,
+        rope_dim=rope_dim,
+        expected_m=tokens,
+    )
+
+    expected = wo_projection_inv_rope_mxfp8(
+        o,
+        positions,
+        cos_sin_cache,
+        weights,
+        heads_per_group=heads_per_group,
+        nope_dim=nope_dim,
+        rope_dim=rope_dim,
+        expected_m=tokens,
+    ).clone()
+    actual = wo_projection_inv_rope_mxfp8(binding=binding)
+    torch.cuda.synchronize()
+    assert actual.data_ptr() == binding.output.data_ptr()
+    torch.testing.assert_close(actual, expected, rtol=0, atol=0)
+
+    graph = torch.cuda.CUDAGraph()
+    with torch.cuda.graph(graph):
+        captured = wo_projection_inv_rope_mxfp8(binding=binding)
+    o.copy_(torch.randn_like(o) / 4)
+    graph.replay()
+    torch.cuda.synchronize()
+    replayed = captured.clone()
+    expected_replay = wo_projection_inv_rope_mxfp8(
+        o,
+        positions,
+        cos_sin_cache,
+        weights,
+        heads_per_group=heads_per_group,
+        nope_dim=nope_dim,
+        rope_dim=rope_dim,
+        expected_m=tokens,
+    ).clone()
+    torch.cuda.synchronize()
+
+    assert captured.data_ptr() == binding.output.data_ptr()
+    torch.testing.assert_close(replayed, expected_replay, rtol=0, atol=0)
 
 
 def test_wo_projection_expected_m_hint_is_byte_identical() -> None:

--- a/tests/gemm/test_gemm_wo_projection.py
+++ b/tests/gemm/test_gemm_wo_projection.py
@@ -776,18 +776,26 @@ def test_inv_rope_fused_wo_replays_under_graph_with_uninitialized_scale_padding(
     torch.testing.assert_close(replayed, expected, rtol=0, atol=0)
 
 
-@pytest.mark.parametrize("tokens", (1, 16))
+@pytest.mark.parametrize(
+    "tokens,dsv4_tp2",
+    [(1, False), (16, False), (8, True), (9, True), (15, True), (16, True), (17, True)],
+)
 def test_inv_rope_planned_wo_uses_bound_arena_and_replays_under_graph(
     tokens: int,
+    dsv4_tp2: bool,
+    monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     require_b12x()
     torch.manual_seed(31014 + tokens)
 
     groups, heads_per_group = 2, 4
     nope_dim, rope_dim = 96, 32
+    rank, hidden = 64, 128
+    if dsv4_tp2:
+        groups, heads_per_group = 4, 1
+        nope_dim, rope_dim, rank, hidden = 448, 64, 1024, 4096
     head_dim = nope_dim + rope_dim
     group_width = heads_per_group * head_dim
-    rank, hidden = 64, 128
     o = (
         torch.randn(
             (tokens, groups * heads_per_group, head_dim),
@@ -802,15 +810,11 @@ def test_inv_rope_planned_wo_uses_bound_arena_and_replays_under_graph(
     )
     cos_sin_cache[:, : rope_dim // 2] = 1
     wo_a = (
-        torch.randn(
-            (groups, rank, group_width), device="cuda", dtype=torch.bfloat16
-        )
+        torch.randn((groups, rank, group_width), device="cuda", dtype=torch.bfloat16)
         / group_width**0.5
     )
     wo_b = (
-        torch.randn(
-            (hidden, groups * rank), device="cuda", dtype=torch.bfloat16
-        )
+        torch.randn((hidden, groups * rank), device="cuda", dtype=torch.bfloat16)
         / (groups * rank) ** 0.5
     )
     weights = quantize_wo_projection_weights_mxfp8_torch(wo_a, wo_b)
@@ -835,17 +839,51 @@ def test_inv_rope_planned_wo_uses_bound_arena_and_replays_under_graph(
         rope_dim=rope_dim,
         expected_m=tokens,
     ).clone()
-    actual = wo_projection_inv_rope_mxfp8(binding=binding)
+    from b12x.gemm._shared import wo_mxfp8 as wo_impl
+
+    def forbid_route_selection(**kwargs):
+        raise AssertionError("bound execution must consume its retained route")
+
+    def run_bound():
+        with monkeypatch.context() as frozen:
+            frozen.setattr(wo_impl, "_select_wo_inv_rope_route", forbid_route_selection)
+            return wo_projection_inv_rope_mxfp8(binding=binding)
+
+    sm_count = torch.cuda.get_device_properties(o.device).multi_processor_count
+    assert binding.route.atomic_output_precleared == (tokens <= 8)
+    assert binding.route.quantized_intermediate == (
+        sm_count <= 64 and (tokens == 16 or (dsv4_tp2 and 9 <= tokens <= 15))
+    )
+    actual = run_bound()
     torch.cuda.synchronize()
     assert actual.data_ptr() == binding.output.data_ptr()
-    torch.testing.assert_close(actual, expected, rtol=0, atol=0)
+
+    def assert_output_matches(actual, expected):
+        if dsv4_tp2 and tokens == 8:
+            # BF16 atomic split-K accumulation can change its summation order.
+            relative = (
+                actual.float() - expected.float()
+            ).norm() / expected.float().norm()
+            cosine = torch.nn.functional.cosine_similarity(
+                actual.float().flatten(), expected.float().flatten(), dim=0
+            )
+            assert relative < 0.005
+            assert cosine > 0.99998
+        else:
+            torch.testing.assert_close(actual, expected, rtol=0, atol=0)
+
+    assert_output_matches(actual, expected)
 
     graph = torch.cuda.CUDAGraph()
     with torch.cuda.graph(graph):
-        captured = wo_projection_inv_rope_mxfp8(binding=binding)
+        captured = run_bound()
     o.copy_(torch.randn_like(o) / 4)
+    captured.fill_(float("nan"))
+    allocated = torch.cuda.memory_allocated()
     graph.replay()
     torch.cuda.synchronize()
+    assert torch.cuda.memory_allocated() == allocated
+    assert torch.isfinite(captured).all() and torch.count_nonzero(captured) > 0
     replayed = captured.clone()
     expected_replay = wo_projection_inv_rope_mxfp8(
         o,
@@ -860,7 +898,7 @@ def test_inv_rope_planned_wo_uses_bound_arena_and_replays_under_graph(
     torch.cuda.synchronize()
 
     assert captured.data_ptr() == binding.output.data_ptr()
-    torch.testing.assert_close(replayed, expected_replay, rtol=0, atol=0)
+    assert_output_matches(replayed, expected_replay)
 
 
 def test_wo_projection_expected_m_hint_is_byte_identical() -> None:

--- a/tests/gemm/test_wo_projection_scratch_bindings.py
+++ b/tests/gemm/test_wo_projection_scratch_bindings.py
@@ -262,3 +262,37 @@ def test_wo_projection_binding_owns_runtime_tensors(monkeypatch) -> None:
             weights,
             binding=binding,
         )
+
+
+@pytest.mark.parametrize(
+    "tokens,sm_count,dsv4,quantized,preclear",
+    [
+        (8, 48, True, False, True),
+        (9, 48, True, True, False),
+        (15, 64, True, True, False),
+        (16, 48, False, True, False),
+        (17, 48, True, False, False),
+        (9, 48, False, False, False),
+        (15, 65, True, False, False),
+        (16, 188, True, False, False),
+    ],
+)
+def test_inv_rope_route_preserves_spark_boundaries(
+    tokens, sm_count, dsv4, quantized, preclear
+):
+    """Keep the Spark-only exact-B16 and DSV4 B9–15 routes distinct."""
+    from types import SimpleNamespace
+
+    weights = SimpleNamespace(
+        groups=4, group_width=512, rank=1024, hidden=4096 if dsv4 else 2048
+    )
+    route = wo_impl._select_wo_inv_rope_route(
+        tokens=tokens,
+        sm_count=sm_count,
+        weights=weights,
+        heads_per_group=1,
+        nope_dim=448,
+        rope_dim=64,
+    )
+    assert route.quantized_intermediate is quantized
+    assert route.atomic_output_precleared is preclear

--- a/tests/gemm/test_wo_projection_scratch_bindings.py
+++ b/tests/gemm/test_wo_projection_scratch_bindings.py
@@ -168,55 +168,54 @@ def test_wo_projection_inv_rope_binding_supplies_runtime_tensors(monkeypatch) ->
     )
     calls = {}
 
-    def fake_fused(
+    def fake_quantize(
         o_arg,
         positions_arg,
         cos_sin_cache_arg,
-        wo_a_values,
-        wo_a_values_tiled,
-        wo_a_scale_rows,
-        wo_a_scale_mma,
-        wo_b_values,
-        wo_b_values_tiled,
-        wo_b_scale_rows,
-        wo_b_scale_mma,
+        out_values,
+        out_scale_rows,
+        out_scale_mma,
+        tokens,
         groups,
-        group_width,
-        rank,
-        hidden,
         heads_per_group,
+        group_width,
+        head_dim,
         nope_dim,
         rope_dim,
-        expected_m,
-        sfb_k_replicated,
-        stream_int,
+        clear_output=None,
     ):
         calls["o"] = o_arg
         calls["positions"] = positions_arg
         calls["cos_sin_cache"] = cos_sin_cache_arg
-        calls["wo_a_values"] = wo_a_values
-        calls["wo_a_scale_rows"] = wo_a_scale_rows
-        calls["wo_a_scale_mma"] = wo_a_scale_mma
-        calls["wo_b_values"] = wo_b_values
-        calls["wo_b_scale_rows"] = wo_b_scale_rows
-        calls["wo_b_scale_mma"] = wo_b_scale_mma
+        calls["x_q_values"] = out_values
+        calls["x_q_scale_rows"] = out_scale_rows
+        calls["x_q_scale_mma"] = out_scale_mma
         calls["groups"] = groups
         calls["group_width"] = group_width
-        calls["rank"] = rank
-        calls["hidden"] = hidden
         calls["heads_per_group"] = heads_per_group
+        calls["head_dim"] = head_dim
         calls["nope_dim"] = nope_dim
         calls["rope_dim"] = rope_dim
-        calls["expected_m"] = expected_m
-        calls["sfb_k_replicated"] = sfb_k_replicated
-        calls["stream_int"] = stream_int
-        return torch.empty((o_arg.shape[0], hidden, 1), dtype=o_arg.dtype)
+        calls["clear_output"] = clear_output
 
-    monkeypatch.setattr(
-        wo_impl.torch.ops.b12x,
-        "wo_projection_inv_rope_mxfp8_fused",
-        fake_fused,
-    )
+    def fake_wo_a(x_q, wo_a, *, out, expected_m=None, stream=None, **kwargs):
+        calls["x_q"] = x_q
+        calls["wo_a"] = wo_a
+        calls["tmp_out"] = out
+        calls["expected_m"] = expected_m
+        calls["wo_a_stream"] = stream
+        return out
+
+    def fake_wo_b(tmp, wo_b, *, out, expected_m=None, stream=None, **kwargs):
+        calls["tmp"] = tmp
+        calls["wo_b"] = wo_b
+        calls["output_out"] = out
+        calls["wo_b_stream"] = stream
+        return out
+
+    monkeypatch.setattr(wo_impl, "_run_wo_a_quant_kernel", fake_quantize)
+    monkeypatch.setattr(wo_impl, "wo_a_dense_gemm_mxfp8", fake_wo_a)
+    monkeypatch.setattr(wo_impl, "wo_b_dense_gemm_fused_quant_mxfp8", fake_wo_b)
 
     out = wo_impl.wo_projection_inv_rope_mxfp8(binding=binding, stream=123)
 
@@ -225,22 +224,26 @@ def test_wo_projection_inv_rope_binding_supplies_runtime_tensors(monkeypatch) ->
     assert calls["o"] is o
     assert calls["positions"] is positions
     assert calls["cos_sin_cache"] is cos_sin_cache
-    assert calls["wo_a_values"] is weights.wo_a.values
-    assert calls["wo_a_scale_rows"] is weights.wo_a.scale_rows
-    assert calls["wo_a_scale_mma"] is weights.wo_a.scale_mma
-    assert calls["wo_b_values"] is weights.wo_b.values
-    assert calls["wo_b_scale_rows"] is weights.wo_b.scale_rows
-    assert calls["wo_b_scale_mma"] is weights.wo_b.scale_mma
+    assert calls["x_q_values"] is binding.x_q.values
+    assert calls["x_q_scale_rows"] is binding.x_q.scale_rows
+    assert calls["x_q_scale_mma"] is binding.x_q.scale_mma
+    assert calls["x_q"] is binding.x_q
+    assert calls["wo_a"] is weights.wo_a
+    assert calls["tmp_out"] is binding.tmp
+    assert calls["tmp"] is binding.tmp
+    assert calls["wo_b"] is weights.wo_b
+    assert calls["output_out"] is binding.output
     assert calls["groups"] == 2
     assert calls["group_width"] == 128
-    assert calls["rank"] == 64
-    assert calls["hidden"] == 256
     assert calls["heads_per_group"] == 1
+    assert calls["head_dim"] == 128
     assert calls["nope_dim"] == 96
     assert calls["rope_dim"] == 32
     assert calls["expected_m"] == 3
-    assert calls["sfb_k_replicated"] == weights.sfb_k_replicated
-    assert calls["stream_int"] == 123
+    assert calls["clear_output"] is binding.output
+    assert calls["wo_a_stream"] == 123
+    assert calls["wo_b_stream"] == 123
+    assert out.data_ptr() == binding.output.data_ptr()
     assert out.shape == (3, 256, 1)
 
 


### PR DESCRIPTION
## Summary

The inverse-RoPE WO binding exposes caller-owned quantization, intermediate and output views, but execution can allocate replacement buffers. Thread the bound views through inverse-RoPE quantization, WO-A, intermediate quantization and WO-B, including the fused small-token path. Return the output backed by the caller's arena.

Resolve the inverse-RoPE route once when constructing a binding and retain it for execution. The functional and bound paths share the existing route rules, including Spark-only quantized WO-A output at 16 tokens and the DSV4 TP2 geometry at 9–15 tokens. That route writes directly into bound `tmp_q` without `alpha_one` or a standalone intermediate quantizer. The small-token WO-B/preclear decision is also retained in the binding.

## Validation

Upstream comparison: master `75ffee6375b0577ce2c8d6931ffacefda3ecbdd6`.

21 targeted cases pass on RTX PRO 6000 Blackwell and GB10 with CUTLASS DSL 4.6.2: 14 CPU binding/route-boundary cases and seven GPU cases. GPU coverage includes the compact 1/16-token geometry and DSV4 TP2 at 8/9/15/16/17 tokens. Tests verify the retained route, forbid route selection during bound execution, compare with the functional path, mutate inputs, poison/replay the output, and check arena pointers and stable allocated bytes. Deterministic routes compare exactly; the DSV4 8-token BF16 atomic split-K control uses relative L2 < 0.005 and cosine > 0.99998 because accumulation order can vary. The original compact arena cases fail on upstream.

```bash
python -m pytest -o addopts= -p no:cacheprovider -q tests/gemm/test_wo_projection_scratch_bindings.py
python -m pytest -o addopts= -p no:cacheprovider -q tests/gemm/test_gemm_wo_projection.py -k inv_rope_planned_wo
```

On GB10, the existing `test_wo_inv_rope_route_fused_small_m_matches_reference_shapes` fails an exact-equality assertion on both upstream and this branch (maximum absolute difference 0.00390625); the targeted arena tests pass. This existing failure is outside the targeted selection above. No performance claim.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

`wo_projection_inv_rope_mxfp8` uses caller-owned scratch, quantization, intermediate, and output views for bound execution. Route selection is fixed during binding and covers atomic output clearing and quantized WO-A intermediates. This preserves arena pointers through inverse-RoPE quantization, WO-A, intermediate quantization, WO-B, and fused small-token execution.

Unbound execution retains the functional path. Bound outputs remain backed by the caller’s arena, satisfying the plan/bind/run storage contract required for CUDA graph replay.

## Validation

- Six CPU binding tests pass.
- GPU tests for 1 and 16 tokens pass on RTX PRO 6000 Blackwell and GB10.
- Tests verify arena pointers, reference results, and CUDA graph replay.
- Six selected inverse-RoPE GPU tests pass on RTX.
- An existing GB10 fused small-token test fails exact equality on both branches, with a maximum absolute difference of `0.00390625`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->