### PR TITLE
fix(attention): reuse planned LSE storage in compressed MLA prefill

### DIFF
--- a/b12x/attention/_shared/mla/compressed_api.py
+++ b/b12x/attention/_shared/mla/compressed_api.py
@@ -353,6 +353,23 @@ def _run_sm120_compressed_prefill(
             q_all=q3,
             v_head_dim=COMPRESSED_SPARSE_MLA_HEAD_DIM,
         )
+    final_lse = getattr(workspace, "final_lse", None)
+    if final_lse is None:
+        raise RuntimeError(
+            "compressed MLA prefill requires caller-owned final_lse scratch"
+        )
+    final_lse = final_lse[: int(q3.shape[0])]
+    if tuple(final_lse.shape) != (int(q3.shape[0]), int(q3.shape[1])):
+        raise ValueError(
+            "compressed MLA final_lse scratch must have live shape "
+            f"{(int(q3.shape[0]), int(q3.shape[1]))}, got {tuple(final_lse.shape)}"
+        )
+    if final_lse.dtype != torch.float32 or final_lse.device != q3.device:
+        raise ValueError(
+            "compressed MLA final_lse scratch must be float32 on the query device"
+        )
+    if not final_lse.is_contiguous():
+        raise ValueError("compressed MLA final_lse scratch must be contiguous")
 
     extra_kwargs: dict = {}
     if indexed_k_cache is not None:
@@ -374,6 +391,7 @@ def _run_sm120_compressed_prefill(
         topk_length=swa_topk_lengths,
         attn_sink=attn_sink,
         output=output,
+        lse_out=final_lse,
         **extra_kwargs,
     )
     if not return_lse:

--- a/tests/attention/test_attention_mla_sm120.py
+++ b/tests/attention/test_attention_mla_sm120.py
@@ -662,6 +662,100 @@ def test_dsv4_compressed_prefill_mode_routes_to_unified_prefill(
 
 
 @torch.inference_mode()
+@pytest.mark.parametrize("mode", ["extend", "verify", "draft_extend"])
+@pytest.mark.parametrize("high_page", [False, True])
+def test_compressed_prefill_reuses_lse_scratch_on_graph_replay(
+    mode: str, high_page: bool
+) -> None:
+    device = require_b12x_sparse_mla()
+    q, compact, compact_indices, lengths = _make_dsv4_compressed_case(
+        device, topk=128, seed=20260909
+    )
+    cache, indices = compact, compact_indices.clone()
+    if high_page:
+        page_bytes = compact.stride(0)
+        first_page = (2**31) // page_bytes + 1
+        cache = torch.empty(
+            (first_page + compact.shape[0], compact.shape[1]),
+            dtype=compact.dtype,
+            device=device,
+        )
+        cache[first_page:].copy_(compact)
+        indices[indices >= 0] += first_page * _DSV4_PAGE
+        assert first_page * page_bytes > 2**31
+    scratch = _make_dsv4_scratch(device, topk=128, max_chunks=8)
+    scratch.mode = mode
+
+    def run():
+        return compressed_sparse_mla_decode_forward(
+            q_all=q,
+            swa_k_cache=cache,
+            swa_indices=indices,
+            swa_topk_lengths=lengths,
+            workspace=scratch,
+            sm_scale=_DSV4_SM_SCALE,
+            swa_page_size=_DSV4_PAGE,
+            return_lse=True,
+            lse_scale="base2",
+        )
+
+    out, lse = run()
+    expected, expected_lse = compressed_sparse_mla_reference(
+        q,
+        compact,
+        compact_indices,
+        lengths,
+        sm_scale=_DSV4_SM_SCALE,
+        swa_page_size=_DSV4_PAGE,
+        return_lse=True,
+    )
+    assert lse.data_ptr() == scratch.final_lse.data_ptr()
+    torch.testing.assert_close(lse * math.log(2), expected_lse, rtol=0, atol=0.02)
+    assert torch.isfinite(out).all() and torch.count_nonzero(out) > 0
+    assert (
+        torch.nn.functional.cosine_similarity(
+            out.float().flatten(), expected.float().flatten(), dim=0
+        )
+        >= 0.999
+    )
+    graph = torch.cuda.CUDAGraph()
+    with torch.cuda.graph(graph):
+        captured_out, captured_lse = run()
+    pointers = captured_out.data_ptr(), captured_lse.data_ptr()
+    for live_length in (7, 31):
+        lengths.fill_(live_length)
+        expected, expected_lse = compressed_sparse_mla_reference(
+            q,
+            compact,
+            compact_indices,
+            lengths,
+            sm_scale=_DSV4_SM_SCALE,
+            swa_page_size=_DSV4_PAGE,
+            return_lse=True,
+        )
+        captured_out.fill_(float("nan"))
+        captured_lse.fill_(float("nan"))
+        allocated = torch.cuda.memory_allocated(device)
+        graph.replay()
+        torch.cuda.synchronize(device)
+        assert torch.cuda.memory_allocated(device) == allocated
+        assert (captured_out.data_ptr(), captured_lse.data_ptr()) == pointers
+        assert captured_lse.data_ptr() == scratch.final_lse.data_ptr()
+        torch.testing.assert_close(
+            captured_lse * math.log(2), expected_lse, rtol=0, atol=0.02
+        )
+        assert (
+            torch.isfinite(captured_out).all() and torch.count_nonzero(captured_out) > 0
+        )
+        assert (
+            torch.nn.functional.cosine_similarity(
+                captured_out.float().flatten(), expected.float().flatten(), dim=0
+            )
+            >= 0.999
+        )
+
+
+@torch.inference_mode()
 def test_dsv4_compressed_decode_extra_cache_routes_to_unified(monkeypatch) -> None:
     """has_extra_cache (indexed/extra-tokens, P7c): the gate routes the DSV4
     dual-cache to SM120 and the result matches dsv4_extra_ref.dsv4_extra_decode_reference

--- a/tests/attention/test_attention_mla_sm120.py
+++ b/tests/attention/test_attention_mla_sm120.py
@@ -615,18 +615,20 @@ def test_dsv4_compressed_prefill_mode_routes_to_unified_prefill(
     compressed_sparse_mla_decode_forward to SM120 sparse MLA.run_unified_prefill (single-pass
     DSV4 prefill), NOT run_unified_decode."""
     device = require_b12x_sparse_mla()
-    routed = {"prefill": 0, "decode": 0}
+    routed = {"prefill": 0, "decode": 0, "lse_ptr": None}
 
-    def fake_run_unified_prefill(*, q, output=None, **kwargs):
+    def fake_run_unified_prefill(*, q, output=None, lse_out=None, **kwargs):
         del kwargs
         routed["prefill"] += 1
+        assert lse_out is not None
+        routed["lse_ptr"] = lse_out.data_ptr()
         if output is not None:
             output.zero_()
             out = output
         else:
             out = q[:, :, :_DSV4_HEAD_DIM].clone()
-        lse = torch.zeros(q.shape[0], q.shape[1], dtype=torch.float32, device=q.device)
-        return out, lse
+        lse_out.zero_()
+        return out, lse_out
 
     def fake_run_unified_decode(**kwargs):
         routed["decode"] += 1
@@ -656,6 +658,7 @@ def test_dsv4_compressed_prefill_mode_routes_to_unified_prefill(
     assert out.shape == (1, _DSV4_HEADS, _DSV4_HEAD_DIM)
     assert routed["prefill"] == 1
     assert routed["decode"] == 0
+    assert routed["lse_ptr"] == scratch.final_lse.data_ptr()
 
 
 @torch.inference_mode()


### PR DESCRIPTION
## Summary

Compressed MLA's extend, verify and draft-extend dispatch supplies the planned output buffer but omits the planned final LSE buffer. The prefill implementation consequently allocates replacement LSE storage. Validate and pass the workspace's final LSE view to the existing prefill entry point.

The regression exercises real prefill execution, compares attention and LSE against the compressed-cache reference, and verifies that replay writes into the caller's output and LSE buffers after poisoning them.

## Validation

Upstream comparison: master `75ffee6375b0577ce2c8d6931ffacefda3ecbdd6`.

Six GPU cases pass on RTX PRO 6000 Blackwell and GB10 with CUTLASS DSL 4.6.2: three prefill modes, each with ordinary page IDs and a mostly uninitialized pool whose live pages are past the 2 GiB offset boundary. Replay changes live sequence lengths while retaining storage addresses and allocated byte count. Three dispatch tests also pass on GB10. Upstream fails the planned-LSE pointer check in all three modes.

```bash
python -m pytest -o addopts= -p no:cacheprovider -q tests/attention/test_attention_mla_sm120.py -k 'compressed_prefill_reuses_lse_scratch or compressed_prefill_mode_routes'
```

The regression requests base-2 LSE. The existing natural-log return conversion is outside this storage change; no claim that every LSE-return mode avoids allocation. No performance claim.
