### PR TITLE
fix(indexer): validate the independently consumed carry halves

### DIFF
--- a/b12x/attention/dsa_indexer/paged.py
+++ b/b12x/attention/dsa_indexer/paged.py
@@ -73,6 +73,25 @@ class _PagedIndexerChunkGeometry:
     token_count: int
 
 
+def _paged_carry_halves_are_contiguous(
+    values: torch.Tensor,
+    indices: torch.Tensor,
+) -> bool:
+    """Return whether each independently launched carry half is contiguous.
+
+    A runtime row prefix of a capacity-sized ``(2, max_rows, topk)`` buffer is
+    not contiguous as one three-dimensional view because the two halves retain
+    their capacity stride.  The tiled top-k kernels consume one two-dimensional
+    half at a time, so those are the views whose layout is authoritative.
+    """
+
+    return all(
+        buffer[half].is_contiguous()
+        for buffer in (values, indices)
+        for half in range(2)
+    )
+
+
 def _paged_indexer_chunk_geometry(
     *,
     chunk_idx: int,
@@ -1009,9 +1028,9 @@ def index_topk_fp8(
                 "paged indexer carry indices must be a CUDA torch.int32 "
                 "tensor on the q_fp8 device"
             )
-        if (
-            not carry_buf_values.is_contiguous()
-            or not carry_buf_indices.is_contiguous()
+        if not _paged_carry_halves_are_contiguous(
+            carry_buf_values,
+            carry_buf_indices,
         ):
             raise ValueError("paged indexer carry buffers must be contiguous")
 

--- a/tests/attention/test_paged_indexer_integration.py
+++ b/tests/attention/test_paged_indexer_integration.py
@@ -5,7 +5,6 @@ import torch
 
 from b12x.attention.dsa_indexer._impl import clear_indexer_caches
 from b12x.attention.dsa_indexer.paged import (
-    _paged_carry_halves_are_contiguous,
     _paged_indexer_chunk_geometry,
     _plan_two_level_fold,
     index_topk_fp8,
@@ -791,6 +790,8 @@ def test_paged_index_shared_supertile_prefill_graph_matches_reference(
 
 
 def test_paged_index_supertile_scratch_sizes_candidate_carry_buffer() -> None:
+    from b12x.attention.dsa_indexer.paged import _paged_carry_halves_are_contiguous
+
     device = torch.device("cpu")
     page_size = 64
     page_table_width = 1056
@@ -1183,3 +1184,89 @@ def test_index_topk_fp8_graph_unaligned_single_chunk(
         torch.sort(actual, dim=1).values,
         torch.sort(expected_raw1, dim=1).values,
     )
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="requires CUDA")
+@pytest.mark.parametrize("live_rows", [2, 4])
+@pytest.mark.parametrize("high_page", [False, True])
+def test_paged_index_carry_capacity_prefix_replays(
+    live_rows: int, high_page: bool
+) -> None:
+    device = torch.device("cuda", torch.cuda.current_device())
+    gen = torch.Generator(device="cpu").manual_seed(20260909)
+    capacity, heads, width, topk, supertile = 8, 32, 192, 512, 4096
+    compact = pack_paged_index_k_cache_reference(
+        (torch.randn((width * 64, 128), generator=gen) / 3).to(device)
+    )
+    cache = compact
+    first_page = 0
+    if high_page:
+        first_page = (2**31) // compact.stride(0) + 1
+        cache = torch.empty(
+            (first_page + compact.shape[0], compact.shape[1]),
+            dtype=compact.dtype,
+            device=device,
+        )
+        cache[first_page:].copy_(compact)
+        assert first_page * compact.stride(0) > 2**31
+    table = torch.arange(width, dtype=torch.int32, device=device).repeat(live_rows, 1)
+    physical_table = table + first_page
+    lengths = torch.full(
+        (live_rows,), width * 64 - 17, dtype=torch.int32, device=device
+    )
+    q = _rand_fp8_q((live_rows, heads, 128), gen=gen, device=device)
+    weights = torch.randn((live_rows, heads), generator=gen).to(device)
+    binding = _bind_paged_indexer(
+        device=device,
+        num_heads=heads,
+        rows=capacity,
+        width_blocks=width,
+        topk=topk,
+        real_page_table=physical_table,
+        seqlens=lengths,
+        supertile_k=supertile,
+    )
+    values, indices = binding.scratch.get_indexer_contiguous_candidate_buffers()
+    assert values.shape[1] == capacity
+    assert not values[:, :live_rows].is_contiguous()
+    assert values[0, :live_rows].is_contiguous()
+    assert binding.route == "paged_tiled"
+    # Integrators retain capacity storage while exposing a capture bucket view.
+    binding.scratch.indexer_contiguous_candidate_values = values[:, :live_rows]
+    binding.scratch.indexer_contiguous_candidate_indices = indices[:, :live_rows]
+    output = torch.empty((live_rows, topk), dtype=torch.int32, device=device)
+
+    def run():
+        return index_topk_fp8(
+            q_fp8=q,
+            weights=weights.unsqueeze(-1),
+            index_k_cache=cache,
+            topk=topk,
+            expected_num_q_heads=heads,
+            binding=binding,
+            out_indices=output,
+            supertile_k=supertile,
+        )
+
+    run()
+    graph = torch.cuda.CUDAGraph()
+    with torch.cuda.graph(graph):
+        run()
+    pointer = output.data_ptr()
+    for length in (width * 64 - 17, 8192 - 37):
+        lengths.fill_(length)
+        expected = _expected_paged_index_topk(
+            q_fp8=q,
+            weights=weights,
+            index_k_cache=compact,
+            real_page_table=table,
+            seqlens=lengths,
+            topk=topk,
+        )
+        output.fill_(-1)
+        allocated = torch.cuda.memory_allocated(device)
+        graph.replay()
+        torch.cuda.synchronize(device)
+        assert output.data_ptr() == pointer
+        assert torch.cuda.memory_allocated(device) == allocated
+        assert torch.equal(output.sort(dim=1).values, expected.sort(dim=1).values)

--- a/tests/attention/test_paged_indexer_integration.py
+++ b/tests/attention/test_paged_indexer_integration.py
@@ -5,6 +5,7 @@ import torch
 
 from b12x.attention.dsa_indexer._impl import clear_indexer_caches
 from b12x.attention.dsa_indexer.paged import (
+    _paged_carry_halves_are_contiguous,
     _paged_indexer_chunk_geometry,
     _plan_two_level_fold,
     index_topk_fp8,
@@ -833,6 +834,15 @@ def test_paged_index_supertile_scratch_sizes_candidate_carry_buffer() -> None:
     # Fold carry double-buffer: exactly two halves, decoupled from chunk_count.
     assert candidate_values.shape[0] == 2
     assert candidate_indices.shape[0] == 2
+
+    # A small capture bucket retains the max-row stride between its two halves,
+    # so the combined 3-D prefix is not contiguous.  Each independently
+    # launched half remains contiguous and is the actual kernel contract.
+    active_values = candidate_values[:, :1, :]
+    active_indices = candidate_indices[:, :1, :]
+    assert not active_values.is_contiguous()
+    assert not active_indices.is_contiguous()
+    assert _paged_carry_halves_are_contiguous(active_values, active_indices)
 
 
 def test_paged_index_supertile_plan_records_launch_contract() -> None:


### PR DESCRIPTION
## Summary

An active prefix of a capacity-sized `(2, max_rows, topk)` carry buffer has a gap between its halves. The combined 3-D view is not contiguous, although each 2-D half passed to the top-k kernels is contiguous. Validate those independently consumed halves so a serving integration can expose its capture bucket without copying capacity storage.

The GPU regression explicitly supplies the active views; merely allocating larger backing storage would not reproduce the rejection.

## Validation

Upstream comparison: master `75ffee6375b0577ce2c8d6931ffacefda3ecbdd6`.

Four GPU cases pass on RTX PRO 6000 Blackwell and GB10 with CUTLASS DSL 4.6.2: 2 and 4 live rows in capacity 8, with ordinary and >2 GiB pool offsets. The real tiled scorer and multi-chunk streaming fold match the reference top-k set during graph replay after changing sequence lengths. Pointers and allocated byte count remain stable. All four cases fail on upstream's contiguity check. The CPU carry-layout regression also passes.

```bash
python -m pytest -o addopts= -p no:cacheprovider -q tests/attention/test_paged_indexer_integration.py -k 'carry_capacity_prefix or supertile_scratch_sizes_candidate'
```

No scoring, selection or route-policy changes; no performance claim.
