### PR TITLE
fix(attention): preserve row-shared compressed MLA index views

### DIFF
--- a/b12x/attention/_shared/mla/compressed_api.py
+++ b/b12x/attention/_shared/mla/compressed_api.py
@@ -183,7 +183,7 @@ def compressed_sparse_mla_decode_forward(
             name="indexed_k_cache",
         )
         indexed_indices_2d = _normalize_index_matrix(
-            indexed_indices, name="indexed_indices"
+            indexed_indices, name="indexed_indices", allow_row_shared=True
         )
         if indexed_indices_2d.device != q3.device:
             raise ValueError("indexed_indices must be on the same device as q_all")
@@ -359,7 +359,7 @@ def _run_sm120_compressed_prefill(
         extra_kwargs = dict(
             extra_kv_cache=indexed_k_cache,
             extra_indices=_normalize_index_matrix(
-                indexed_indices, name="indexed_indices"
+                indexed_indices, name="indexed_indices", allow_row_shared=True
             ),
             extra_topk_length=indexed_topk_lengths,
             extra_page_block_size=int(indexed_page_size),

--- a/b12x/attention/_shared/mla/kernel.py
+++ b/b12x/attention/_shared/mla/kernel.py
@@ -2766,7 +2766,12 @@ def run_unified_decode(
             model_type=int(model_type),
         )
         extra_kv_flat = _cache_base_tensor(indexed_k_cache)
-        extra_indices_t = indexed_indices.contiguous()
+        extra_indices_t = (
+            indexed_indices
+            if int(indexed_indices.stride(0)) == 0
+            and int(indexed_indices.stride(1)) == 1
+            else indexed_indices.contiguous()
+        )
     else:
         pbs_extra = 1
         stride_extra_kv_block = 0

--- a/b12x/attention/_shared/mla/prefill_mg.py
+++ b/b12x/attention/_shared/mla/prefill_mg.py
@@ -4288,7 +4288,12 @@ def run_unified_prefill_mg(
         num_extra_tiles = (extra_topk + _CAND_WINDOW - 1) // _CAND_WINDOW
         num_tiles = num_main_tiles + num_extra_tiles
         row_xor = pbs_extra == 2
-        extra_indices_t = extra_indices.contiguous()
+        extra_indices_t = (
+            extra_indices
+            if int(extra_indices.stride(0)) == 0
+            and int(extra_indices.stride(1)) == 1
+            else extra_indices.contiguous()
+        )
         if extra_topk_length is None:
             extra_len_t = torch.full(
                 (num_tokens,), extra_topk, dtype=torch.int32, device=device

--- a/b12x/attention/compressed_sparse_mla/_scratch.py
+++ b/b12x/attention/compressed_sparse_mla/_scratch.py
@@ -597,6 +597,7 @@ def build_compressed_sparse_mla_binding(
             scratch=scratch,
             rows=rows,
             name="indexed_indices",
+            allow_row_shared=True,
         )
         indexed_width = int(indexed_indices.shape[1])
         max_indexed_width = int(

--- a/tests/attention/test_attention_mla_compressed.py
+++ b/tests/attention/test_attention_mla_compressed.py
@@ -793,6 +793,118 @@ def test_compressed_sparse_mla_shared_core_replays_under_cuda_graph() -> None:
 
 
 @torch.inference_mode()
+@pytest.mark.parametrize("high_page", [False, True])
+@pytest.mark.parametrize("mode", ["decode", "extend"])
+def test_compressed_mla_row_shared_indices_replay(high_page: bool, mode: str) -> None:
+    device = require_b12x()
+    clear_mla_caches()
+    rows = 4
+    q = _make_q(rows=rows, seed=20260909, device=device)
+    swa_compact = _make_cache(
+        tokens=32,
+        page_size=COMPRESSED_SPARSE_MLA_DSV4_PAGE_SIZE,
+        seed=31,
+        device=device,
+    )
+    extra_compact = _make_cache(
+        tokens=32,
+        page_size=COMPRESSED_SPARSE_MLA_C128_PAGE_SIZE,
+        seed=32,
+        device=device,
+    )
+    swa_reference_indices = torch.full(
+        (rows, 128), -1, dtype=torch.int32, device=device
+    )
+    swa_reference_indices[:, :16] = torch.arange(16, dtype=torch.int32, device=device)
+    extra_reference_indices = torch.full((1, 64), -1, dtype=torch.int32, device=device)
+    extra_reference_indices[:, :16] = torch.arange(16, dtype=torch.int32, device=device)
+    swa_indices = swa_reference_indices.clone()
+    extra_base = extra_reference_indices.clone()
+    swa_cache, extra_cache = swa_compact, extra_compact
+    if high_page:
+        pools = []
+        for compact, indices, page_size in (
+            (swa_compact, swa_indices, COMPRESSED_SPARSE_MLA_DSV4_PAGE_SIZE),
+            (extra_compact, extra_base, COMPRESSED_SPARSE_MLA_C128_PAGE_SIZE),
+        ):
+            first_page = (2**31) // compact.stride(0) + 1
+            pool = torch.empty(
+                (first_page + compact.shape[0], compact.shape[1]),
+                dtype=compact.dtype,
+                device=device,
+            )
+            pool[first_page:].copy_(compact)
+            indices[indices >= 0] += first_page * page_size
+            assert first_page * compact.stride(0) > 2**31
+            pools.append(pool)
+        swa_cache, extra_cache = pools
+    extra_indices = extra_base.expand(rows, -1)
+    assert extra_indices.stride() == (0, 1)
+    swa_lengths = torch.full((rows,), 11, dtype=torch.int32, device=device)
+    extra_lengths = torch.full((rows,), 7, dtype=torch.int32, device=device)
+    binding = _make_compressed_binding(
+        device=device,
+        rows=rows,
+        topk=192,
+        max_kv_rows=rows * 192,
+        q=q,
+        swa_indices=swa_indices,
+        swa_lengths=swa_lengths,
+        indexed_indices=extra_indices,
+        indexed_lengths=extra_lengths,
+        use_cuda_graph=True,
+    )
+    binding.scratch.mode = mode
+    assert binding.indexed_indices is extra_indices
+
+    def run():
+        return compressed_sparse_mla_decode_forward(
+            swa_k_cache=swa_cache,
+            binding=binding,
+            indexed_k_cache=extra_cache,
+            indexed_page_size=COMPRESSED_SPARSE_MLA_C128_PAGE_SIZE,
+            sm_scale=_SM_SCALE,
+        )
+
+    def reference():
+        return compressed_sparse_mla_reference(
+            q,
+            swa_compact,
+            swa_reference_indices,
+            swa_lengths,
+            extra_k_cache=extra_compact,
+            extra_indices=extra_reference_indices.expand(rows, -1),
+            extra_topk_lengths=extra_lengths,
+            extra_page_size=COMPRESSED_SPARSE_MLA_C128_PAGE_SIZE,
+            sm_scale=_SM_SCALE,
+        )
+
+    run()
+    graph = torch.cuda.CUDAGraph()
+    with torch.cuda.graph(graph):
+        captured = run()
+    pointer = captured.data_ptr()
+    for live_length in (7, 3):
+        extra_lengths.fill_(live_length)
+        captured.fill_(float("nan"))
+        expected = reference()
+        allocated = torch.cuda.memory_allocated(device)
+        graph.replay()
+        torch.cuda.synchronize(device)
+        assert torch.cuda.memory_allocated(device) == allocated
+        assert captured.data_ptr() == pointer
+        assert binding.indexed_indices.data_ptr() == extra_base.data_ptr()
+        assert torch.isfinite(captured).all() and torch.count_nonzero(captured) > 0
+        assert (captured.float() - expected.float()).abs().max() <= 0.10
+        assert (
+            torch.nn.functional.cosine_similarity(
+                captured.float().flatten(), expected.float().flatten(), dim=0
+            )
+            >= 0.9995
+        )
+
+
+@torch.inference_mode()
 def test_compressed_sparse_mla_c128_pv_row_swizzle_replays_under_cuda_graph() -> None:
     device = require_b12x()
     clear_mla_caches()

--- a/tests/attention/test_compressed_sparse_scratch_bindings.py
+++ b/tests/attention/test_compressed_sparse_scratch_bindings.py
@@ -679,6 +679,26 @@ def test_compressed_sparse_mla_bind_accepts_row_shared_page_table() -> None:
     assert binding.indexed_page_table.stride() == (0, 1)
 
 
+def test_compressed_sparse_mla_bind_accepts_row_shared_indexed_indices() -> None:
+    workspace = _workspace(topk=6, max_page_table_width=5)
+    q = torch.empty((4, 2, 512), dtype=torch.bfloat16)
+    swa_indices = torch.empty((4, 2), dtype=torch.int32)
+    swa_lengths = torch.empty((4,), dtype=torch.int32)
+    indexed_indices = torch.empty((1, 4), dtype=torch.int32).expand(4, -1)
+    indexed_lengths = torch.empty((4,), dtype=torch.int32)
+
+    binding = workspace.bind_compressed_sparse_mla(
+        q=q,
+        swa_indices=swa_indices,
+        swa_lengths=swa_lengths,
+        indexed_indices=indexed_indices,
+        indexed_lengths=indexed_lengths,
+    )
+
+    assert binding.indexed_indices is indexed_indices
+    assert binding.indexed_indices.stride() == (0, 1)
+
+
 def test_workspace_bind_sparse_mla_returns_common_binding_type() -> None:
     workspace = _workspace(topk=6, max_page_table_width=5)
     q = torch.empty((4, 2, 512), dtype=torch.bfloat16)


### PR DESCRIPTION
## Summary

Compressed MLA rejects an expanded `int32` index matrix with stride `(0, 1)` at binding, and its launch wrappers materialize a contiguous copy. Accept that existing row-shared indexed-cache layout and preserve it through decode and prefill. The kernels already receive the row stride.

This lets callers share one index row across query rows using the existing dual-cache operation and caller-owned storage.

## Validation

Upstream comparison: master `75ffee6375b0577ce2c8d6931ffacefda3ecbdd6`.

Four real GPU cases pass on RTX PRO 6000 Blackwell and GB10 with CUTLASS DSL 4.6.2: decode/extend with ordinary and >2 GiB offsets in both cache pools. The tests use a padded 64-entry shared index row, mutate live lengths, poison/replay output, check the compressed-cache reference (cosine >= 0.9995, max absolute error <= 0.10), and preserve pointers and allocated byte count. Two CPU binding tests pass. Upstream rejects the same views at binding.

```bash
python -m pytest -o addopts= -p no:cacheprovider -q tests/attention/test_attention_mla_compressed.py tests/attention/test_compressed_sparse_scratch_bindings.py -k 'row_shared_indices_replay or bind_accepts_row_shared'
```

A separate GB10 diagnostic with an unpadded 16-entry extra-index row produces an illegal access in extend on both this branch and upstream using contiguous indices. This PR does not fix that pre-existing partial-tile issue. No performance claim.
