### PR TITLE
fix(gemm): bound MXFP8 weight-scale reads on swizzle padding

### DIFF
--- a/b12x/_lib/dense_gemm.py
+++ b/b12x/_lib/dense_gemm.py
@@ -4200,9 +4200,27 @@ class DenseGemmKernel:
                             sfa_pair = ld_global_b16(
                                 get_ptr_as_int64(directSFA_mkl, sfa_offset)
                             )
-                            sfb_pair = ld_global_b16(
-                                get_ptr_as_int64(directSFB_nkl, sfb_offset)
-                            )
+                            # The persistent swizzle rounds N tiles up to its
+                            # raster width. TMA zero-fills these extra B tiles,
+                            # but the packed scale allocation contains only
+                            # ceil(N/128) atoms. Scalar loads need the same
+                            # bound; unit scales keep the zero-filled tile inert.
+                            if cutlass.const_expr(
+                                tile_sched_params.swizzle_size > 1
+                                and ((directB_nkl.shape[0] + 127) // 128)
+                                % tile_sched_params.swizzle_size != 0
+                            ):
+                                sfb_pair = Uint32(0x7F7F)
+                                if sfb_tile < Int32(
+                                    (directB_nkl.shape[0] + 127) // 128
+                                ):
+                                    sfb_pair = ld_global_b16(
+                                        get_ptr_as_int64(directSFB_nkl, sfb_offset)
+                                    )
+                            else:
+                                sfb_pair = ld_global_b16(
+                                    get_ptr_as_int64(directSFB_nkl, sfb_offset)
+                                )
                             sfa_smem_addr = shared_ptr_to_u32(
                                 elem_pointer(
                                     sSFA,

--- a/tests/gemm/test_mxfp8_linear.py
+++ b/tests/gemm/test_mxfp8_linear.py
@@ -121,6 +121,60 @@ def test_mm_persistent_ctas_complete_single_stage_epilogue_stores() -> None:
         assert torch.all(actual == in_features)
 
 
+@pytest.mark.parametrize("out_features", (12448, 12544, 14336))
+def test_mm_prefill_swizzle_bounds_weight_scales(out_features: int) -> None:
+    """BK64 swizzle padding must not read beyond the packed weight scales.
+
+    N=12448 is a TP2 GLM KDA projection; N=12544 has full scale atoms but
+    a partial 16-tile raster; N=14336 has a complete raster. Run under
+    compute-sanitizer with PYTORCH_NO_CUDA_MEMORY_CACHING=1 for access bounds.
+    """
+    require_b12x()
+    require_mxf8_mma()
+    import b12x
+
+    capacity, in_features = 4096, 4096
+    source = torch.ones((capacity, in_features), dtype=torch.bfloat16, device="cuda")
+    weight = torch.ones(
+        (out_features, in_features), dtype=torch.float8_e4m3fn, device="cuda"
+    )
+    exponents = torch.arange(out_features, device="cuda") % 4 - 2
+    scales = (exponents + 127).to(torch.uint8)[:, None].expand(
+        out_features, in_features // 32
+    ).contiguous()
+    packed = blockscaled.pack_weight(weight, scales)
+    expected = (in_features * 2.0 ** exponents).to(torch.bfloat16)
+
+    for tokens in (137, 2048, capacity):
+        actual = blockscaled.mm(
+            source[:tokens], packed, mode="quantized", expected_m=capacity
+        )
+        torch.cuda.synchronize()
+        torch.testing.assert_close(actual, expected.expand(tokens, -1), rtol=0, atol=0)
+
+    b12x.freeze_kernel_resolution("MXFP8 swizzled prefill scale bounds")
+    try:
+        for tokens in (127, 257):
+            graph = torch.cuda.CUDAGraph()
+            with torch.cuda.graph(graph):
+                actual = blockscaled.mm(
+                    source[:tokens], packed, mode="quantized", expected_m=capacity
+                )
+            address = actual.data_ptr()
+            for multiplier in (0.5, 2.0, 1.0):
+                source.fill_(multiplier)
+                actual.fill_(float("nan"))
+                graph.replay()
+                torch.cuda.synchronize()
+                assert actual.data_ptr() == address
+                torch.testing.assert_close(
+                    actual, (expected * multiplier).expand(tokens, -1), rtol=0, atol=0
+                )
+            graph.reset()
+    finally:
+        b12x.unfreeze_kernel_resolution()
+
+
 @pytest.mark.parametrize("tokens", (2, 3, 8, 15, 16, 17, 32, 99))
 def test_mm_writes_all_rows_for_unaligned_output_width(tokens: int) -> None:
     """A small-batch GEMM must store every live row when N spans multiple tiles."""


### PR DESCRIPTION
## Problem

The persistent MXFP8 GEMM scheduler can visit padded N tiles beyond the packed weight-scale allocation. TMA zero-fills the corresponding weight operands, but manual two-byte scale loads were not bounded.

The GLM Spark TP2 KDA projection reproduces this with **M=4096, N=12448, K=4096**, a 128×128×64 tile, and a 16-column swizzle: the scale allocation contains **98 column atoms**, while the scheduler visits **112 tiles**. N=12544 also fails, so rounding N to a multiple of 128 is insufficient. Compute Sanitizer reports invalid global weight-scale reads on unmodified B12X.

## Fix and compatibility

Bound manual weight-scale reads to the physical allocation and stage UE8M0 unit scales for zero-filled padding tiles. Full swizzle rasters retain the unguarded compiled path.

Quantization, logical tensor dimensions, valid weight/scale values, reduction order, launch geometry, output dtype, and workspace ownership are unchanged. There is no padded weight copy or backend fallback. This is a correctness fix, not a claimed kernel speedup.

The PR contains the exact published image commit `73f66f028c1b59e92728e9fbbe4a472bb7796248`: one kernel file and its regression tests. It targets `master` and merges without text conflicts into the inspected head `323107ff948ca532f1f7c793b4b550c30ba5212b`.

## Validation

Status: implemented and qualified on RTX PRO 6000 Workstation at the GEMM boundary, then exercised by the Spark TP2 serving image.

| Check | Result |
|---|---|
| Unmodified kernel, N=12448 and N=12544, uncached allocations | Invalid two-byte scale reads; execution fails. |
| Fixed kernel, exact all-ones GLM projection, Compute Sanitizer | Three exact outputs of 4096; zero sanitizer errors. Component runs used stock VRAM clocks. |
| `tests/gemm/test_mxfp8_linear.py` | 23 passed: partial/full swizzle rasters, nonuniform scales, live M changes, and poisoned graph replay with frozen kernel resolution. |
| Dense planner tests | 264 passed. |
| Published Spark TP2/DCP2 MTP3 image | Cold 1M-context image request, post-image text, mixed serving and text-prefix checks passed. Serving tests used VRAM +6000. |

Run the included regression suite in the isolated B12X environment:

```bash
.venv/bin/python -m pytest tests/gemm/test_mxfp8_linear.py -q
```

To expose physical allocation bounds independently of PyTorch's caching allocator, run the parametrized regression under Compute Sanitizer:

```bash
PYTORCH_NO_CUDA_MEMORY_CACHING=1 compute-sanitizer \
  --tool memcheck --error-exitcode 1 \
  .venv/bin/python -m pytest \
  'tests/gemm/test_mxfp8_linear.py::test_mm_prefill_swizzle_bounds_weight_scales[12448]' -q
```

The recorded sanitizer result above used an equivalent standalone public `blockscaled.pack_weight` / `blockscaled.mm` probe with finite all-ones operands. The pytest command is the repository-contained reproducer; it additionally covers nonuniform scales and graph replay. No model download is needed.

Ruff checks and `git diff --check` pass. Full-file formatter checks also request changes on the unmodified parent; unrelated formatting is deliberately excluded.

[Published image and serving qualification](https://github.com/local-inference-lab/rtx6kpro/blob/master/models/glm-5.3-flash-spark-tp2.md). The companion [vLLM #739 memory PR](https://github.com/local-inference-lab/vllm/pull/739) is required to reproduce that capacity; this kernel fix alone does not provide 1M context. The combination with subsequent master commits has not been rebenchmarked.

Duplicate-work audit found no open PR addressing this scalar scale-load bound. MXFP8 projection-overlap and fused-quantizer PRs (#307/#288) are distinct mechanisms. AI assistance was used for implementation, testing and PR preparation; the original author and commit are preserved.
